### PR TITLE
 add bootstrap to install docker and fl-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Funless Testing Repo
+
+This repo contains utilities and projects to setup a testing environment for the funless platform.
+
+In the `vagrant` folder you can use vagrant to spin up some VMs to deploy and test funless,
+running: `vagrant up --provider=libvirt`.
+
+It spins up 3 VMs with docker installed on them and fl-cli installed.
+
+To remove them use `vagrant destroy -f`. (the -f is to skip confirming.)

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,7 +3,7 @@
 
 # ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
-VAGRANT_BOX         = "ubuntu/focal64"
+VAGRANT_BOX         = "generic/ubuntu2204"
 CPU_NODE            = 1
 MEMORY_NODE         = 1024
 WORKER_NODES_COUNT  = 2
@@ -20,12 +20,6 @@ Vagrant.configure(2) do |config|
     node.vm.hostname          = "core.funless.dev"
 
     node.vm.network "private_network", ip: "192.168.56.100"
-  
-    node.vm.provider :virtualbox do |v|
-      v.name    = "core"
-      v.memory  = MEMORY_NODE
-      v.cpus    = CPU_NODE
-    end
   
     node.vm.provider :libvirt do |v|
       v.memory  = MEMORY_NODE
@@ -48,12 +42,6 @@ Vagrant.configure(2) do |config|
       node.vm.hostname          = "worker#{i}.funless.dev"
 
       node.vm.network "private_network", ip: "192.168.56.10#{i}"
-
-      node.vm.provider :virtualbox do |v|
-        v.name    = "worker#{i}"
-        v.memory  = MEMORY_NODE
-        v.cpus    = CPU_NODE
-      end
 
       node.vm.provider :libvirt do |v|
         v.memory  = MEMORY_NODE

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -9,3 +9,25 @@ EOF
 
 # echo "[TASK 2] Stop and Disable firewall"
 # systemctl disable --now ufw >/dev/null 2>&1
+
+echo "[TASK 2] Install Docker"
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+echo "[TASK 3] Install go"
+wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz
+echo "export PATH=$PATH:/usr/local/go/bin" >> /etc/profile
+source /etc/profile
+
+echo "[TASK 4] Install task"
+sudo snap install task --classic
+
+echo "[TASK 5] Clone fl-cli"
+git clone https://github.com/funlessdev/fl-cli.git
+
+echo "[TASK 6] Install fl-cli"
+cd fl-cli
+task install

--- a/vagrant/bootstrap_core.sh
+++ b/vagrant/bootstrap_core.sh
@@ -1,7 +1,2 @@
 #!/bin/bash
 
-echo "[TASK 1] Get Core release"
-
-echo "[TASK 2] Start Core release"
-
-

--- a/vagrant/bootstrap_worker.sh
+++ b/vagrant/bootstrap_worker.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
 
-echo "[TASK 1] Get Worker release"
-
-echo "[TASK 2] Start Worker release"


### PR DESCRIPTION
This PR adds the bootstrap.sh script (ran in all vms) to spin up 3 VMs with docker installed and the fl-cli built and installed in the system.

This way it is easy to start VMs and deploy funless via the cli tool to test manually the platform.